### PR TITLE
Add org-bibtex/ol-bibtex handle to itemgetters

### DIFF
--- a/citeproc-itemgetters.el
+++ b/citeproc-itemgetters.el
@@ -29,6 +29,10 @@
 
 (require 'dash)
 (require 'org)
+;; Handle the fact that org-bibtex has been renamed to ol-bibtex -- for the time
+;; being we support both feature names.
+(or (require 'ol-bibtex nil t)
+    (require 'org-bibtex))
 (require 'org-bibtex)
 (require 'json)
 (require 'bibtex)


### PR DESCRIPTION
Without this code, I get errors when using `citeproc-org` because `org-bibtex` doesn't exist. I don't think this should break anything -- it's the same snippet that's used to handle `org-bibtex` in other places in the package.