### PR TITLE
Remove org-bibtex from itemgetters

### DIFF
--- a/citeproc-itemgetters.el
+++ b/citeproc-itemgetters.el
@@ -33,7 +33,6 @@
 ;; being we support both feature names.
 (or (require 'ol-bibtex nil t)
     (require 'org-bibtex))
-(require 'org-bibtex)
 (require 'json)
 (require 'bibtex)
 


### PR DESCRIPTION
I accidentally left the old `require` statement in there. `org-bibtex` will be loaded by legacy code on the previous line. Sorry about that!