### PR TITLE
Initial nocite support

### DIFF
--- a/citeproc-cite.el
+++ b/citeproc-cite.el
@@ -514,6 +514,7 @@ Possible values are 'last, 'first and 'subsequent.")
 (defun citeproc-proc-finalize (proc)
   "Finalize processor PROC by sorting and disambiguating items."
   (unless (citeproc-proc-finalized proc)
+    (citeproc-proc-process-uncited proc)
     (citeproc-proc-update-sortkeys proc)
     (citeproc-proc-sort-itds proc)
     (citeproc-proc-update-positions proc)

--- a/citeproc-itemgetters.el
+++ b/citeproc-itemgetters.el
@@ -165,10 +165,14 @@ Supported formats:
 	  t (list file)))
         (ext
          (user-error "Unknown bibliography extension: %S" ext))))
-    (lambda (itemids)
-      (mapcar (lambda (id)
-                (cons id (gethash id cache)))
-              itemids))))
+    (lambda (x)
+      (pcase x
+	('itemids
+	 (hash-table-keys cache))
+	((pred listp) (mapcar (lambda (id)
+				  (cons id (gethash id cache)))
+				x))
+	(_ (error "Unsupported citeproc itemgetter retrieval method"))))))
 
 (provide 'citeproc-itemgetters)
 

--- a/citeproc.el
+++ b/citeproc.el
@@ -94,6 +94,14 @@ CITATIONS is a list of `citeproc-citation' structures."
 	(queue-append (citeproc-proc-citations proc) citation))
       (setf (citeproc-proc-finalized proc) nil))))
 
+(defun citeproc-add-uncited (itemids proc)
+  "Add uncited bib items with ITEMIDS to PROC.
+As an extension, an itemid can be the string \"*\" which has the
+effect of adding all items available in the itemgetter."
+  ;; We simply store the added ids here, real processing is performed when the
+  ;; processor is finalized.
+  (push itemids (citeproc-proc-uncited proc)))
+
 (defun citeproc-render-citations (proc format &optional internal-links)
   "Render all citations in PROC in the given FORMAT.
 Return a list of formatted citations.


### PR DESCRIPTION
Adds nocite support with the crucial limitation that disambiguation treats all items as if they were cited.