### PR TITLE
Fix for latex bibliographies that have urls with '#' in them

### DIFF
--- a/citeproc-formatters.el
+++ b/citeproc-formatters.el
@@ -275,7 +275,7 @@ CSL tests."
     (font-weight-bold . ,(lambda (x) (concat "\\textbf{" x "}")))
     (cited-item-no . ,(lambda (x y) (concat "\\citeprocitem{" y "}{" x "}")))
     (bib-item-no . ,(lambda (x y) (concat "\\hypertarget{citeproc_bib_item_" y "}{"
-					  x "}")))
+					  (citeproc-fmt--latex-escape x) "}")))
     (font-variant-small-caps . ,(lambda (x) (concat "\\textsc{" x "}")))
     (text-decoration-underline . ,(lambda (x) (concat "\\underline{" x "}")))
     (vertical-align-sup . ,(lambda (x) (concat "\\textsuperscript{" x "}")))

--- a/citeproc-formatters.el
+++ b/citeproc-formatters.el
@@ -275,7 +275,7 @@ CSL tests."
     (font-weight-bold . ,(lambda (x) (concat "\\textbf{" x "}")))
     (cited-item-no . ,(lambda (x y) (concat "\\citeprocitem{" y "}{" x "}")))
     (bib-item-no . ,(lambda (x y) (concat "\\hypertarget{citeproc_bib_item_" y "}{"
-					  (citeproc-fmt--latex-escape x) "}")))
+					  (replace-regexp-in-string (regexp-opt '("#")) "\\\\\\&" x) "}")))
     (font-variant-small-caps . ,(lambda (x) (concat "\\textsc{" x "}")))
     (text-decoration-underline . ,(lambda (x) (concat "\\underline{" x "}")))
     (vertical-align-sup . ,(lambda (x) (concat "\\textsuperscript{" x "}")))


### PR DESCRIPTION
The latex output wasn't escaping `#` in urls, which was causing the latex to pdf processor `pdflatex` to error out. This only seems to arise out of `\hypertarget{...}{...\url{...}}` sort of formatting, where the url in `\url` has a `#` in it. I couldn't workaround this resource with urlencoded urls because the ISO site doesn't like that, so I had to dig a little more to find out how to fix it properly.

Example `test.org` file:

```org
#+title: Example org file
#+cite_export: csl ./chicago-fullnote-bibliography.csl
#+bibliography: ./references.bib

- Prolog ISO Standard [cite:@iso_prolog]

* Bibliography

#+print_bibliography: t
```

Example `references.bib` file:
```bibtex
@techreport{iso_prolog,
  title = {Prolog — Part 1: General core},
  shorttitle = {{ISO}/{IEC} 13211-1:1995},
  url = {https://www.iso.org/obp/ui/#iso:std:iso-iec:13211:-1:ed-1:v1:en},
  language = {en},
  number = {ISO/IEC 13211-1:1995},
  institution = {International Organization for Standardization},
  author = {{ISO Information Technology}},
  year = {1995}
}
```

- CSL file used: https://github.com/citation-style-language/styles/blob/master/chicago-fullnote-bibliography.csl
- Example output: [test.pdf](https://github.com/user-attachments/files/15757494/test.pdf)

